### PR TITLE
GlueX updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/include)
 link_directories(${ROOT_LIBRARY_DIR})
 link_directories(${CMSG_LIBRARY_DIR})
 link_directories(${xmsg_DIR}/../..)
+link_directories(${CMAKE_INSTALL_PREFIX}/lib)
 
 add_subdirectory(src/libRootSpy)
 add_subdirectory(src/libRootSpy-client)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,14 @@ find_package(Protobuf REQUIRED)
 find_package(ZeroMQ REQUIRED)
 find_package(CURL REQUIRED)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
-find_package(EZCA REQUIRED)
-add_compile_definitions(HAVE_EZCA=1)
+find_package(EZCA)
+if (EZCA_FOUND)
+    add_compile_definitions(HAVE_EZCA=1)
+    include_directories(${EZCA_INCLUDE_DIRS})
+else()
+    message(WARNING "EZCA not found so EPICS support will not be included (set EPICS_BASE and EPICS_HOST_ARCH to specify location)")
+    
+endif()
 
 # cmsg
 set(CMSG_ROOT "$ENV{cmsg_ROOT}")
@@ -43,7 +49,6 @@ include_directories(${CMSG_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/libRootSpy-client)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/libRootSpy)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/include)
-include_directories(${EZCA_INCLUDE_DIRS})
 
 # Library directories
 link_directories(${ROOT_LIBRARY_DIR})

--- a/src/RSAI/CMakeLists.txt
+++ b/src/RSAI/CMakeLists.txt
@@ -3,5 +3,7 @@ project(RSAI)
 add_executable(RSAI RSAI.cc)
 
 target_link_libraries(RSAI RootSpy-client)
-set_target_properties(RSAI PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-
+set_target_properties(RSAI PROPERTIES
+    INSTALL_RPATH_USE_LINK_PATH TRUE
+    BUILD_WITH_INSTALL_RPATH TRUE
+)

--- a/src/RSAI/RSAI.cc
+++ b/src/RSAI/RSAI.cc
@@ -595,7 +595,7 @@ void ResetCanvas(TCanvas* c) {
   
 	// finally, update the display
 	c->Update();
-  }
+}
 
 //-----------
 // ParseCommandLineArguments

--- a/src/RootSpy/CMakeLists.txt
+++ b/src/RootSpy/CMakeLists.txt
@@ -14,9 +14,15 @@ target_link_libraries(RootSpyExe
   PRIVATE
     RootSpy-client
     ROOT::Core ROOT::RIO ROOT::Hist ROOT::Gui ROOT::GuiBld ROOT::RootAuth
-    ${EZCA_LIBRARIES}
     ${READLINE_LIBRARY}
 )
+
+if (EZCA_FOUND)
+  target_link_libraries(RootSpyExe
+    PRIVATE
+      ${EZCA_LIBRARIES}
+  )
+endif()
 
 set_target_properties(RootSpyExe PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE

--- a/src/RootSpy/rs_mainframe.h
+++ b/src/RootSpy/rs_mainframe.h
@@ -162,6 +162,7 @@ class rs_mainframe:public TGMainFrame {
 
 		viewStyle_t_rs viewStyle_rs;
 		void ExecuteMacro(TDirectory* f, string macro);
+		void ResetCanvas(TCanvas* c);
 		void DrawMacro(TCanvas*the_canvas, hinfo_t &the_hinfo);
 		void DrawMacro(TCanvas*the_canvas, hdef_t &the_hdef);
 		void DropAllHists(void);


### PR DESCRIPTION
Multiple fixes:

- Reset multiple TCanvas parameters before executing new macro to prevent macro bleedthrough
- Make EZCA option in cmake builds
- Add install lib to rpath so installed libRootSpy-client can be found without setting LD_LIBRARY_PATH