### PR TITLE
Fix race condition for RSAI and possible RSelog linking issue

### DIFF
--- a/src/RSAI/RSAI.cc
+++ b/src/RSAI/RSAI.cc
@@ -274,7 +274,9 @@ void MainLoop(void)
 			if( ! rs_PadsToSave.empty() ){
 
 				// Save whole canvas to temporary file.
-				string tmp_img_fname = OUTPUT_DIR + "/tmp_canvas.png";
+				// string tmp_img_fname = OUTPUT_DIR + "/tmp_canvas.png";
+				pid_t pid = getpid();
+				string tmp_img_fname = OUTPUT_DIR + "/tmp_canvas_" + std::to_string(pid) + ".png";
 				c1->Update();
 				c1->SaveAs(tmp_img_fname.c_str());
 

--- a/src/RSelog/CMakeLists.txt
+++ b/src/RSelog/CMakeLists.txt
@@ -6,5 +6,8 @@ add_executable(RSelog RSelog.cc)
 
 # Link with libraries (assuming libRootSpy-client is built as a library)
 target_link_libraries(RSelog RootSpy-client ${ROOT_LIBRARIES} ${CMSG_LIBRARIES} ${xmsg_LIBRARIES} ${Protobuf_LIBRARIES} ${CURL_LIBRARIES})
-set_target_properties(RSelog PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+set_target_properties(RSelog PROPERTIES 
+    INSTALL_RPATH_USE_LINK_PATH TRUE
+    BUILD_WITH_INSTALL_RPATH TRUE
+)
 


### PR DESCRIPTION
Add the PID of the process to the tmp_canvas.png filename. This should avoid the possible conflict between two simultaneous RSAI instances both trying to write to the same file. That was a possible cause of an image file's content not matching the name. It may also be the cause of some all black images.

Also added BUILD_WITH_INSTALL_RPATH to RSelog CMakeLists.txt. This may have not been needed, but there was a report that elog entries for RootSpy were not working recently and this was something that could cause that. This makes it linking more consistent with the other RS programs.